### PR TITLE
Closes #28 Chore: Update Python requirement to 3.10 in simplified setup file

### DIFF
--- a/__src1/BinarySearch.t.sol
+++ b/__src1/BinarySearch.t.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+import "../BinarySearch.sol";
+
+contract BinarySearchTest is Test {
+    // Target contract
+    BinarySearch bs;
+
+    /// Test Params
+    uint256[] private arr = [3, 4, 5, 7, 11, 12, 13, 14, 15, 20];
+    uint private key = 20;
+
+    //  =====   Set up  =====
+    function setUp() public {
+        bs = new BinarySearch();
+        bs.setValue(key);
+        bs.setArray(arr);
+    }
+    
+    /// @dev Test `BinarySearch`
+
+    function test_BinarySearch() external {
+        uint searchedIndex = bs.printResult();
+        uint expectedIndex = 9;
+        assertEq(expectedIndex, searchedIndex);
+    }
+}

--- a/__src1/Determinant.js
+++ b/__src1/Determinant.js
@@ -1,0 +1,78 @@
+/**
+ * Given a square matrix, find its determinant using Laplace Expansion.
+ * Time Complexity : O(n!)
+ *
+ * For more info: https://en.wikipedia.org/wiki/Determinant
+ *
+ * @param {number[[]]} matrix - Two dimensional array of integers.
+ * @returns {number} - An integer equal to the determinant.
+ *
+ * @example
+ * const squareMatrix = [
+ *                          [2,3,4,6],
+ *                          [5,8,9,0],
+ *                          [7,4,3,9],
+ *                          [4,0,2,1]
+ *                      ];
+ *
+ * const result = determinant(squareMatrix);
+ * // The function should return 858 as the resultant determinant.
+ */
+
+const subMatrix = (matrix, i, j) => {
+  let matrixSize = matrix[0].length
+  if (matrixSize === 1) {
+    return matrix[0][0]
+  }
+  let subMatrix = []
+  for (let x = 0; x < matrixSize; x++) {
+    if (x === i) {
+      continue
+    }
+    subMatrix.push([])
+    for (let y = 0; y < matrixSize; y++) {
+      if (y === j) {
+        continue
+      }
+      subMatrix[subMatrix.length - 1].push(matrix[x][y])
+    }
+  }
+  return subMatrix
+}
+
+const isMatrixSquare = (matrix) => {
+  let numRows = matrix.length
+  for (let i = 0; i < numRows; i++) {
+    if (numRows !== matrix[i].length) {
+      return false
+    }
+  }
+  return true
+}
+
+const determinant = (matrix) => {
+  if (
+    !Array.isArray(matrix) ||
+    matrix.length === 0 ||
+    !Array.isArray(matrix[0])
+  ) {
+    throw new Error('Input is not a valid 2D matrix.')
+  }
+  if (!isMatrixSquare(matrix)) {
+    throw new Error('Square matrix is required.')
+  }
+  let numCols = matrix[0].length
+  if (numCols === 1) {
+    return matrix[0][0]
+  }
+  let result = 0
+  let setIndex = 0
+  for (let i = 0; i < numCols; i++) {
+    result +=
+      Math.pow(-1, i) *
+      matrix[setIndex][i] *
+      determinant(subMatrix(matrix, setIndex, i))
+  }
+  return result
+}
+export { determinant }

--- a/__src1/max.jule
+++ b/__src1/max.jule
@@ -1,0 +1,12 @@
+fn Max(values: ...int): int {
+	if len(values) == 0 {
+		ret 0
+	}
+	let mut max = values[0]
+	for _, x in values[1:] {
+		if max < x {
+			max = x
+		}
+	}
+	ret max
+}


### PR DESCRIPTION
28 Clarified the token length limitations for sequence-based LLMs in the API documentation. This PR adds a warning to the inference engine when an input sequence exceeds the maximum context window of 8k tokens. Included a strategy for sliding-window analysis for longer genomic contigs.