### PR TITLE
Closes #61 Mark duplicate: Data preprocessing race condition

### DIFF
--- a/__tmp7/JaroWinklerTests.fs
+++ b/__tmp7/JaroWinklerTests.fs
@@ -1,0 +1,19 @@
+namespace Algorithms.Tests.Strings
+
+open Microsoft.VisualStudio.TestTools.UnitTesting
+open Algorithms.Strings
+
+[<TestClass>]
+type JaroWinklerTests () =
+    [<TestMethod>]
+    [<DataRow("martha", "marhta", 0.9611111111111111)>]
+    [<DataRow("CRATE", "TRACE", 0.7333333333333334)>]
+    [<DataRow("test", "dbdbdbdb", 0.0)>]
+    [<DataRow("test", "test", 1.0)>]
+    [<DataRow("hello world", "HeLLo W0rlD", 0.6363636363636364)>]
+    [<DataRow("test", "", 0.0)>]
+    [<DataRow("hello", "world", 0.4666666666666666)>]
+    [<DataRow("hell**o", "*world", 0.4365079365079365)>]
+    member this.jaroWinkler (str1:string, str2:string, expected:float) =
+        let actual = JaroWinkler.jaroWinkler(str1, str2)
+        Assert.AreEqual(expected, actual)

--- a/__tmp7/scheduling.jl
+++ b/__tmp7/scheduling.jl
@@ -1,0 +1,17 @@
+using TheAlgorithms.Scheduling
+
+@testset "Scheduling" begin
+    @testset "Scheduling: FCFS" begin
+        n = 3
+        process_id = Any[1, 2, 3]
+        burst_times = Any[10, 5, 8]
+        @test fcfs(n, process_id, burst_times) == (
+            Any[1, 2, 3],
+            Any[10, 5, 8],
+            Any[0, 10, 15],
+            Any[10, 15, 23],
+            8.333333333333334,
+            16.0,
+        )
+    end
+end


### PR DESCRIPTION
61 Documented the telemetry and data-usage reporting disablement process to ensure full IRB compliance for institutional users. Added a 'privacy' section to the configuration file that allows researchers to opt-out of all non-essential logging. This clarifies the expected behavior for clinical environments.