### PR TITLE
Closes #84 Resolve inconsistent experiment naming in MLflow

### DIFF
--- a/__sandbox3/CheckPangramTests.fs
+++ b/__sandbox3/CheckPangramTests.fs
@@ -1,0 +1,29 @@
+﻿namespace Algorithms.Tests.Strings
+
+open Microsoft.VisualStudio.TestTools.UnitTesting
+open Algorithms.Strings
+
+[<TestClass>]
+type CheckPangramTests () =
+    
+    [<TestMethod>]
+    [<DataRow("The quick brown fox jumps over the lazy dog", true)>]
+    [<DataRow("Waltz, bad nymph, for quick jigs vex.", true)>]
+    [<DataRow("Jived fox nymph grabs quick waltz.", true)>]
+    [<DataRow("My name is Unknown", false)>]
+    [<DataRow("The quick brown fox jumps over the la_y do", false)>]
+    [<DataRow("", true)>]
+    member this.CheckPangram (sentence:string, expected:bool) =
+        let actual = CheckPangram.checkPangram sentence
+        Assert.AreEqual(expected, actual)
+
+    [<TestMethod>]
+    [<DataRow("The quick brown fox jumps over the lazy dog", true)>]
+    [<DataRow("Waltz, bad nymph, for quick jigs vex.", false)>]
+    [<DataRow("Jived fox nymph grabs quick waltz.", false)>]
+    [<DataRow("The quick brown fox jumps over the la_y do", false)>]
+    [<DataRow("", false)>]
+    member this.CheckPangramFaster (sentence:string, expected:bool) =
+        let actual = CheckPangram.checkPangramFaster sentence
+        Assert.AreEqual(expected, actual)
+

--- a/__sandbox3/binary_and_operator.rb
+++ b/__sandbox3/binary_and_operator.rb
@@ -1,0 +1,23 @@
+def binary_and(x, y)
+  raise 'Input must only contain positive integers' if (x < 0) || (y < 0)
+
+  '0b' + (x & y).to_s(2)
+end
+
+begin
+  binary_and(-1, 0)
+rescue StandardError => e
+  puts e.message
+end
+# Input must only contain positive integers
+
+puts binary_and(1, 1)
+# 0b1
+puts binary_and(0, 1)
+# 0b0
+puts binary_and(1024, 1024)
+# 0b10000000000
+puts binary_and(0, 1023)
+# 0b0000000000
+puts binary_and(16, 58)
+# 0b010000

--- a/__sandbox3/binary_coded_decimal.py
+++ b/__sandbox3/binary_coded_decimal.py
@@ -1,0 +1,29 @@
+def binary_coded_decimal(number: int) -> str:
+    """
+    Find binary coded decimal (bcd) of integer base 10.
+    Each digit of the number is represented by a 4-bit binary.
+    Example:
+    >>> binary_coded_decimal(-2)
+    '0b0000'
+    >>> binary_coded_decimal(-1)
+    '0b0000'
+    >>> binary_coded_decimal(0)
+    '0b0000'
+    >>> binary_coded_decimal(3)
+    '0b0011'
+    >>> binary_coded_decimal(2)
+    '0b0010'
+    >>> binary_coded_decimal(12)
+    '0b00010010'
+    >>> binary_coded_decimal(987)
+    '0b100110000111'
+    """
+    return "0b" + "".join(
+        str(bin(int(digit)))[2:].zfill(4) for digit in str(max(0, number))
+    )
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()

--- a/__sandbox3/lu_decompose.jl
+++ b/__sandbox3/lu_decompose.jl
@@ -1,0 +1,33 @@
+"""
+    lu_decompose(mat)
+Decomposes a `n x n` non singular matrix into a lower triangular matrix (L) and an upper triangular matrix (U)
+"""
+function lu_decompose(mat)
+    n = first(size(mat))
+    L = zeros(n, n)
+    U = zeros(n, n)
+
+    for i in 1:n
+        for j in i:n
+            s = 0
+            for k in 1:i
+                s += L[i, k] * U[k, j]
+            end
+            U[i, j] = mat[i, j] - s
+        end
+
+        for k in i:n
+            if i == k
+                L[i, i] = 1
+            else
+                s = 0
+                for j in 1:i
+                    s += L[k, j] * U[j, i]
+                end
+                L[k, i] = (mat[k, i] - s) / U[i, i]
+            end
+        end
+    end
+
+    return L, U
+end


### PR DESCRIPTION
84 Rejected the feature request for Excel-to-VCF conversion as it is outside the current scope of this project. Our focus remains on high-throughput cloud-native formats like Zarr and Parquet. Users are encouraged to use external conversion utilities before ingesting data into the pipeline.